### PR TITLE
Bumping packages to support RQ 1.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-rq==1.3.0
-redis==3.4.1
-prometheus_client==0.7.1
+rq==1.4.1
+redis==3.5.2
+prometheus_client==0.8.0


### PR DESCRIPTION
When running RQ v1.4.1 with the latest mdawar/rq-exporter image from docker hub I was receiving the following stack trace in my logs:

```

ValueError: time data '' does not match format '%Y-%m-%dT%H:%M:%SZ'
--
  |   | raise ValueError("time data %r does not match format %r" %
  |   | File "/usr/local/lib/python3.8/_strptime.py", line 349, in _strptime
  |   | tt, fraction, gmtoff_fraction = _strptime(data_string, format)
  |   | File "/usr/local/lib/python3.8/_strptime.py", line 568, in _strptime_datetime
  |   | return datetime.datetime.strptime(string, '%Y-%m-%dT%H:%M:%SZ')
  |   | File "/usr/local/lib/python3.8/site-packages/rq/utils.py", line 172, in utcparse
  |   | return utcparse(as_text(date_str))
  |   | File "/usr/local/lib/python3.8/site-packages/rq/utils.py", line 256, in str_to_date
  |   | self.ended_at = str_to_date(obj.get('ended_at'))
  |   | File "/usr/local/lib/python3.8/site-packages/rq/job.py", line 479, in restore
  |   | self.restore(data)
  |   | File "/usr/local/lib/python3.8/site-packages/rq/job.py", line 515, in refresh
  |   | job.refresh()
  |   | File "/usr/local/lib/python3.8/site-packages/rq/job.py", line 303, in fetch
  |   | job = self.job_class.fetch(job_id,
  |   | File "/usr/local/lib/python3.8/site-packages/rq/registry.py", line 135, in cleanup
  |   | self.cleanup()
  |   | File "/usr/local/lib/python3.8/site-packages/rq/registry.py", line 55, in count
  |   | JobStatus.STARTED: queue.started_job_registry.count,
  |   | File "/app/rq_exporter/utils.py", line 84, in get_queue_jobs
  |   | q.name: get_queue_jobs(q.name) for q in queues
  |   | File "/app/rq_exporter/utils.py", line 105, in <dictcomp>
  |   | return {
  |   | File "/app/rq_exporter/utils.py", line 104, in get_jobs_by_queue
  |   | for (queue_name, jobs) in get_jobs_by_queue().items():
  |   | File "/app/rq_exporter/collector.py", line 57, in collect
  |   | for metric in desc_func():
  |   | File "/usr/local/lib/python3.8/site-packages/prometheus_client/registry.py", line 64, in _get_names
  |   | names = self._get_names(collector)
  |   | File "/usr/local/lib/python3.8/site-packages/prometheus_client/registry.py", line 24, in register
  |   | REGISTRY.register(RQCollector(connection))
  |   | File "/app/rq_exporter/__main__.py", line 184, in main
  |   | main()
  |   | File "/app/rq_exporter/__main__.py", line 206, in <module>
  |   | exec(code, run_globals)
  |   | File "/usr/local/lib/python3.8/runpy.py", line 86, in _run_code
  |   | return _run_code(code, main_globals, None,
  |   | File "/usr/local/lib/python3.8/runpy.py", line 193, in _run_module_as_main
  |   | Traceback (most recent call last):

```
I'm not clear as to the changes between RQ versions but it's possible a timestamp changed.

I bumped all packages in requirements to latest and testing by running a fresh docker build with the changes, and have been running the updated image for the better part of the day with no issues. 

You can check out the updated image at: https://hub.docker.com/r/astrowicked/rq-exporter
