### PR TITLE
Export job start/end times (#3)

### DIFF
--- a/docker-compose/project/enqueue.py
+++ b/docker-compose/project/enqueue.py
@@ -21,7 +21,7 @@ def main(custom_classes=False):
 
     while True:
         # Choose a random job
-        job = random.choice((jobs.long_running_job, jobs.process_data))
+        job = random.choice((jobs.long_running_job, jobs.process_data, jobs.short_running_job))
 
         # Choose a random queue
         queue = random.choice(queues_list)

--- a/docker-compose/project/jobs.py
+++ b/docker-compose/project/jobs.py
@@ -14,6 +14,14 @@ def long_running_job(s=10):
     return s
 
 
+def short_running_job(s=10):
+    s = s/10
+    print(f'long_running_job: sleeping for {s} seconds')
+    time.sleep(s)
+
+    return s
+
+
 def process_data(s=10):
     print(f'process_data: sleeping for {s} seconds')
     time.sleep(s)

--- a/grafana/rq-dashboard.json
+++ b/grafana/rq-dashboard.json
@@ -1735,6 +1735,190 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$DS_PROMETHEUS",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 46
+      },
+      "hiddenSeries": false,
+      "id": 31,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideZero": true,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "nullPointMode": "null as zero",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(rq_timings_sum{job=\"$job\", instance=\"$instance\"}) by (func_name)",
+          "interval": "",
+          "legendFormat": "{{func_name}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Average completion time by job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "s",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$DS_PROMETHEUS",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 46
+      },
+      "hiddenSeries": false,
+      "id": 32,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideZero": true,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "nullPointMode": "null as zero",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(rq_timings_sum{job=\"$job\", instance=\"$instance\"}) by (queue)",
+          "interval": "",
+          "legendFormat": "{{queue}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Average completion time by queue",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "s",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": "",

--- a/rq_exporter/utils.py
+++ b/rq_exporter/utils.py
@@ -85,7 +85,7 @@ def get_job_timings(job):
     }
 
 
-def get_registry_timings(connection, job_registry, limit=-1):
+def get_registry_timings(connection, job_registry, limit=3):
     """Get the timings for jobs in a Registry.
 
     Args:
@@ -99,7 +99,7 @@ def get_registry_timings(connection, job_registry, limit=-1):
         redis.exceptions.RedisError: On Redis connection errors
 
     """
-    job_ids = job_registry.get_job_ids(end=limit)
+    job_ids = job_registry.get_job_ids(start=limit*-1, end=-1)
     jobs = Job.fetch_many(job_ids, connection=connection)
 
     return {

--- a/rq_exporter/utils.py
+++ b/rq_exporter/utils.py
@@ -70,10 +70,13 @@ def get_workers_stats(worker_class=None):
 
 
 def get_job_timings(job):
-    """
+    """Get stats for the RQ job.
+
+    Args:
+        job (rq.job.Job): an instance of a RQ job
 
     Returns:
-        dict:
+        dict: Dictionary of basic runtime stats for the job
 
     """
     # Runtime should never be -1 unless the job is not from a finished_job_registry
@@ -93,12 +96,13 @@ def get_registry_timings(connection, job_registry, limit=3):
         limit (int): The max number of jobs to retrieve
 
     Returns:
-        dict: 
+        dict: Dictionary of job id to a dict of the job's stats
 
     Raises:
         redis.exceptions.RedisError: On Redis connection errors
 
     """
+    # Jobs are added in RQ with zscore of current time + ttl, fetch by last completed
     job_ids = job_registry.get_job_ids(start=limit*-1, end=-1)
     jobs = Job.fetch_many(job_ids, connection=connection)
 
@@ -165,7 +169,7 @@ def get_finished_registries_by_queue(connection, queue_class=None):
         queue_class (type): RQ Queue class
 
     Returns:
-        dict: Dictionary of job count by status for each queue
+        dict: Dictionary of queues with nested runtime stats
 
     Raises:
         redis.exceptions.RedisError: On Redis connection errors


### PR DESCRIPTION
Per #3 , thought I'd open a PR and we can move specific discussions here. Can consider this an early draft, and here's what the added panels look like atm.

![runtime panels](https://user-images.githubusercontent.com/17535601/93138545-6818ac80-f69c-11ea-9e4c-6d20408936d6.png)

A short running job was added to show the difference.

Some decisions that were made:

Using `SummaryMetricFamily` - the other options would have been `GaugeMetricFamily` or `HistogramMetricFamily`. Histograms require pre-defined buckets which I don't think would be a good fit as the runtimes wouldn't be generic, instead a Summary Metric uses rolling time windows. It's adding the data individually per scraped job so the `count_value` is `1` and the `sum_value` is only what that job's calculated runtime was; so this is a bit strange - Gauge Metrics may work instead.

Currently it scrapes the 3 most recently completed jobs per queue which gives the above panels. Will look at option flags for this.

Timestamps are specified when it adds job runtime data, this is taken from the `job.ended_at`. This does have the effect that since Prometheus is append-only, that when we scrape jobs which completed prior to the last scrape, those old jobs will not be added. Instead Prometheus will throw an `Error on ingesting out-of-order samples` and drop them. I believe this should mean that it never stores jobs as duplicates and only displays the latest data. Could also use a better approach for this.

Data labels are the `job.func_name` and the queue.

Still left to do:
- feature flag
- could investigate using `enqueued_at` in a different metric

Other things:

To you earlier point https://github.com/mdawar/rq-exporter/issues/3#issuecomment-667305691, if the job completes and is removed before a scrape, there is still no information about it. So scrape times have to be within the jobs ttl which should be the case unless the ttl was manually specified to be pretty short.

I would say I'm still uncertain about using a Summary Metric - I think it's meant for when the exporter is able to calculate something like total response time for a whole group of responses? In other words, when the `count_value` is > 1, and the `sum_value` would be the sum of these individual samples. Running `avg()` on this metric seems to make logical sense for now: `long_running_job`s complete within `random.randint(2, 10)` as displayed, and `short_running_jobs`s complete within that div 10.

I think using timestamps does get around issues with the data being inaccurate, as it should have only the latest jobs completed since last scrape. If that works, it should mean not having to scrape all jobs from the finished and failed registries and instead focus on getting a "what's the performance like right now" question.

Anyways, let me know your thoughts and can go from there.