### PR TITLE
Set numeric user to comply runAsNonRoot k8s policy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.8-slim-buster
 
 # Create a user and a group
-RUN groupadd -r exporter && useradd -r -g exporter exporter
+RUN groupadd -r exporter && useradd -r -g exporter exporter -u 999
 
 # Create the /app directory and set the owner
 RUN mkdir /app \
@@ -16,6 +16,6 @@ RUN pip install --no-cache-dir -r /app/requirements.txt
 # Copy the build context (defined in .dockerignore)
 COPY . /app
 
-USER exporter
+USER 999
 
 ENTRYPOINT ["python", "-m", "rq_exporter"]


### PR DESCRIPTION
When in k8s, container has `runAsNonRoot` policy and image has non-numeric user (exporter), then the deployment will fail as it cannot verify user is non-root.

Closes #20

Signed-off-by: Aleksandr Vinokurov <aleksandr.vin@gmail.com>