### PR TITLE
Add SSL support for redis URLs beginning with rediss

### DIFF
--- a/rq_exporter/utils.py
+++ b/rq_exporter/utils.py
@@ -2,6 +2,7 @@
 RQ exporter utility functions.
 
 """
+from urllib.parse import urlparse
 
 from redis import Redis
 from redis.sentinel import Sentinel
@@ -37,7 +38,18 @@ def get_redis_connection(host='localhost', port='6379', db='0', sentinel=None,
 
     """
     if url:
-        return Redis.from_url(url)
+        if url.startswith("rediss://"):
+            parsed = urlparse(url)
+            return Redis(
+                host=parsed.hostname,
+                port=parsed.port,
+                username=parsed.username,
+                password=parsed.password,
+                ssl=True,
+                ssl_cert_reqs=None,
+            )
+        else:
+            return Redis.from_url(url)
 
     # Use password file if provided
     if password_file:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,6 +31,22 @@ class GetRedisConnectionTestCase(unittest.TestCase):
             self.assertEqual(connection, Redis.from_url.return_value)
 
     @patch('builtins.open', mock_open())
+    def test_creating_redis_connection_from_url_with_ssl(self):
+        """When the `url` argument with SSL is passed the connection must be created with `Redis`."""
+        with patch('rq_exporter.utils.Redis') as Redis:
+            connection = get_redis_connection(url='rediss://user:pass@host:1234')
+
+            Redis.assert_called_with(
+                host="host", port=1234, username="user", password="pass", ssl=True, ssl_cert_reqs=None
+            )
+
+            open.assert_not_called()
+
+            Redis.assert_called()
+
+            self.assertEqual(connection, Redis.return_value)
+
+    @patch('builtins.open', mock_open())
     def test_creating_redis_connection_without_url(self):
         """When the `url` argument is not set the connection must be created from the other options."""
         with patch('rq_exporter.utils.Redis') as Redis:


### PR DESCRIPTION
For some reason `Redis.from_url` doesn't work with redis urls beginning with `rediss://`.  This is a problem if you do have secure redis instances for example on Heroku.

This change will allow for secure redis urls beginning with `rediss://` by instantiating a redis connection with the parsed url along with `ssl=True`.