### PR TITLE
New metrics

### DIFF
--- a/rq_exporter/collector.py
+++ b/rq_exporter/collector.py
@@ -51,7 +51,7 @@ class RQCollector(object):
         with self.summary.time():
             with Connection(self.connection):
                 rq_workers = GaugeMetricFamily('rq_workers', 'RQ workers', labels=['name', 'state', 'queues'])
-                rq_workers_success = CounterMetricFamily('rq_workers_success', 'RQ workers success count', labels=['name'])
+                rq_workers_success = CounterMetricFamily('rq_workers_success', 'RQ workers success count', labels=['name', 'queues'])
                 rq_workers_failed = CounterMetricFamily('rq_workers_failed', 'RQ workers fail count', labels=['name', 'queues'])
                 rq_workers_working_time = CounterMetricFamily('rq_workers_working_time', 'RQ workers spent seconds', labels=['name', 'queues'])
 

--- a/rq_exporter/collector.py
+++ b/rq_exporter/collector.py
@@ -5,12 +5,12 @@ RQ metrics collector.
 
 import logging
 
+from prometheus_client.metrics_core import CounterMetricFamily
 from rq import Connection
 from prometheus_client import Summary
 from prometheus_client.core import GaugeMetricFamily
 
 from .utils import get_workers_stats, get_jobs_by_queue
-
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +24,7 @@ class RQCollector(object):
         queue_class (type): RQ Queue class
 
     """
+
     def __init__(self, connection=None, worker_class=None, queue_class=None):
         self.connection = connection
         self.worker_class = worker_class
@@ -50,12 +51,24 @@ class RQCollector(object):
         with self.summary.time():
             with Connection(self.connection):
                 rq_workers = GaugeMetricFamily('rq_workers', 'RQ workers', labels=['name', 'state', 'queues'])
+                rq_workers_success = CounterMetricFamily('rq_workers_success', 'RQ workers success count', labels=['name'])
+                rq_workers_failed = CounterMetricFamily('rq_workers_failed', 'RQ workers fail count', labels=['name', 'queues'])
+                rq_workers_working_time = CounterMetricFamily('rq_workers_working_time', 'RQ workers spent seconds', labels=['name', 'queues'])
+
                 rq_jobs = GaugeMetricFamily('rq_jobs', 'RQ jobs by state', labels=['queue', 'status'])
 
-                for worker in get_workers_stats(self.worker_class):
-                    rq_workers.add_metric([worker['name'], worker['state'], ','.join(worker['queues'])], 1)
+                workers = get_workers_stats(self.worker_class)
+                for worker in workers:
+                    label_queues = ','.join(worker['queues'])
+                    rq_workers.add_metric([worker['name'], worker['state'], label_queues], 1)
+                    rq_workers_success.add_metric([worker['name'], label_queues], worker['successful_job_count'])
+                    rq_workers_failed.add_metric([worker['name'], label_queues], worker['failed_job_count'])
+                    rq_workers_working_time.add_metric([worker['name'], label_queues], worker['total_working_time'])
 
                 yield rq_workers
+                yield rq_workers_success
+                yield rq_workers_failed
+                yield rq_workers_working_time
 
                 for (queue_name, jobs) in get_jobs_by_queue(self.queue_class).items():
                     for (status, count) in jobs.items():

--- a/rq_exporter/utils.py
+++ b/rq_exporter/utils.py
@@ -73,7 +73,10 @@ def get_workers_stats(worker_class=None):
         {
             'name': w.name,
             'queues': w.queue_names(),
-            'state': w.get_state()
+            'state': w.get_state(),
+            'successful_job_count': w.successful_job_count,
+            'failed_job_count': w.failed_job_count,
+            'total_working_time': w.total_working_time
         }
         for w in workers
     ]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -162,14 +162,20 @@ class GetWorkersStatsTestCase(unittest.TestCase):
         worker_one.configure_mock(**{
             'name': 'worker_one',
             'queue_names.return_value': ['default'],
-            'get_state.return_value': 'idle'
+            'get_state.return_value': 'idle',
+            'successful_job_count': 1,
+            'failed_job_count': 2,
+            'total_working_time': 3
         })
 
         worker_two = Mock()
         worker_two.configure_mock(**{
             'name': 'worker_two',
             'queue_names.return_value': ['high', 'default', 'low'],
-            'get_state.return_value': 'busy'
+            'get_state.return_value': 'busy',
+            'successful_job_count': 4,
+            'failed_job_count': 5,
+            'total_working_time': 6
         })
 
         Worker.all.return_value = [worker_one, worker_two]
@@ -184,14 +190,20 @@ class GetWorkersStatsTestCase(unittest.TestCase):
                 {
                     'name': 'worker_one',
                     'queues': ['default'],
-                    'state': 'idle'
+                    'state': 'idle',
+                    'successful_job_count': 1,
+                    'failed_job_count': 2,
+                    'total_working_time': 3
                 },
                 {
                     'name': 'worker_two',
                     'queues': ['high', 'default', 'low'],
-                    'state': 'busy'
+                    'state': 'busy',
+                    'successful_job_count': 4,
+                    'failed_job_count': 5,
+                    'total_working_time': 6
                 }
-            ]
+        ]
         )
 
     @patch('rq_exporter.utils.Worker')


### PR DESCRIPTION
I've added some 3 metrics that rq exposes:

* successful_job_count
* failed_job_count
* total_working_time

By dividing total_working_time by successful_job_count and failed_job_count you can get avg task latency which is useful to track.
