### PR TITLE
fix: avoid clean up when querying queue job count

### DIFF
--- a/rq_exporter/utils.py
+++ b/rq_exporter/utils.py
@@ -112,7 +112,7 @@ def get_queue_jobs(connection, queue_name, queue_class=None):
     queue = queue_class(connection=connection, name=queue_name)
 
     return {
-        JobStatus.QUEUED: queue.get_job_count(cleanup=False),
+        JobStatus.QUEUED: queue.count,
         JobStatus.STARTED: queue.started_job_registry.get_job_count(cleanup=False),
         JobStatus.FINISHED: queue.finished_job_registry.get_job_count(cleanup=False),
         JobStatus.FAILED: queue.failed_job_registry.get_job_count(cleanup=False),

--- a/rq_exporter/utils.py
+++ b/rq_exporter/utils.py
@@ -112,12 +112,12 @@ def get_queue_jobs(connection, queue_name, queue_class=None):
     queue = queue_class(connection=connection, name=queue_name)
 
     return {
-        JobStatus.QUEUED: queue.count,
-        JobStatus.STARTED: queue.started_job_registry.count,
-        JobStatus.FINISHED: queue.finished_job_registry.count,
-        JobStatus.FAILED: queue.failed_job_registry.count,
-        JobStatus.DEFERRED: queue.deferred_job_registry.count,
-        JobStatus.SCHEDULED: queue.scheduled_job_registry.count
+        JobStatus.QUEUED: queue.get_job_count(cleanup=False),
+        JobStatus.STARTED: queue.started_job_registry.get_job_count(cleanup=False),
+        JobStatus.FINISHED: queue.finished_job_registry.get_job_count(cleanup=False),
+        JobStatus.FAILED: queue.failed_job_registry.get_job_count(cleanup=False),
+        JobStatus.DEFERRED: queue.deferred_job_registry.get_job_count(cleanup=False),
+        JobStatus.SCHEDULED: queue.scheduled_job_registry.get_job_count(cleanup=False)
     }
 
 


### PR DESCRIPTION
Hello there,

Amazing project, it has been really useful for a project I've been working on!

While using this exporter I noticed that, because we are defining a custom cleanup function, the exporter would fail to start.

This is because the exporter doesn't have the application code needed for running jobs (which it shouldn't have anyway!).

Here is an example stack trace:

```bash
Traceback (most recent call last):
  File ".venv/lib/python3.12/site-packages/rq/utils.py", line 158, in import_attribute
    return __builtins__[name]  # type: ignore[index]
           ~~~~~~~~~~~~^^^^^^
KeyError: 'worker.rq.failure_callback'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File ".venv/bin/rq-exporter", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File ".venv/lib/python3.12/site-packages/rq_exporter/__main__.py", line 241, in main
    REGISTRY.register(RQCollector(connection, worker_class, queue_class))
  File ".venv/lib/python3.12/site-packages/prometheus_client/registry.py", line 40, in register
    names = self._get_names(collector)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.12/site-packages/prometheus_client/registry.py", line 80, in _get_names
    for metric in desc_func():
  File ".venv/lib/python3.12/site-packages/rq_exporter/collector.py", line 94, in collect
    for (queue_name, jobs) in get_jobs_by_queue(self.connection, self.queue_class).items():
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.12/site-packages/rq_exporter/utils.py", line 143, in get_jobs_by_queue
    q.name: get_queue_jobs(connection, q.name, queue_class) for q in queues
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.12/site-packages/rq_exporter/utils.py", line 116, in get_queue_jobs
    JobStatus.STARTED: queue.started_job_registry.count,
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.12/site-packages/rq/registry.py", line 92, in count
    return self.get_job_count(cleanup=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.12/site-packages/rq/registry.py", line 104, in get_job_count
    self.cleanup()
  File ".venv/lib/python3.12/site-packages/rq/registry.py", line 278, in cleanup
    job.execute_failure_callback(
  File ".venv/lib/python3.12/site-packages/rq/job.py", line 1484, in execute_failure_callback
    if not self.failure_callback:
           ^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.12/site-packages/rq/job.py", line 511, in failure_callback
    self._failure_callback = import_attribute(self._failure_callback_name)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.12/site-packages/rq/utils.py", line 160, in import_attribute
    raise ValueError(f'Invalid attribute name: {name}')
ValueError: Invalid attribute name: worker.rq.failure_callback
```

Let me know if that makes sense, happy to elaborate more! 
